### PR TITLE
Add fields and relationships to Skills entity

### DIFF
--- a/src/main/java/com/shosha/springboot/demo/jopportal/entity/Skills.java
+++ b/src/main/java/com/shosha/springboot/demo/jopportal/entity/Skills.java
@@ -1,13 +1,25 @@
 package com.shosha.springboot.demo.jopportal.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
 
+@Setter
+@Getter
 @Entity
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
 @Table(name = "skills")
 public class Skills {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
+    private int id;
 
+    private String name;
+    private String experienceLevel;
+    private String yearsOfExperience;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "job_seeker_profile")
+    private JobSeekerProfile jobSeekerProfile;
 }


### PR DESCRIPTION
Added new fields: name, experienceLevel, and yearsOfExperience. Introduced a many-to-one relationship with JobSeekerProfile and applied Lombok annotations for boilerplate code reduction. These changes enhance the functionality and maintainability of the Skills entity.