### PR TITLE
"Add PasswordEncoder bean configuration for user service"

### DIFF
--- a/src/main/java/com/shosha/springboot/demo/jopportal/config/WebSecurityConfig.java
+++ b/src/main/java/com/shosha/springboot/demo/jopportal/config/WebSecurityConfig.java
@@ -60,14 +60,16 @@ public class WebSecurityConfig {
         return http.build();
     }
 
-    private AuthenticationProvider authenticationProvider() {
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
         DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
         authenticationProvider.setPasswordEncoder(passwordEncoder());
         authenticationProvider.setUserDetailsService(customUserDetailsService);
         return authenticationProvider;
     }
 
-    private PasswordEncoder passwordEncoder() {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/shosha/springboot/demo/jopportal/controller/HomeController.java
+++ b/src/main/java/com/shosha/springboot/demo/jopportal/controller/HomeController.java
@@ -50,7 +50,7 @@ public class HomeController {
             return "register";
         } else {
             usersService.addNew(user);
-            return "dashboard";
+            return "redirect:/dashboard/";
         }
     }
 


### PR DESCRIPTION
This commit adds a PasswordEncoder bean to the configuration, resolving the issue where PasswordEncoder was missing from the context. "Fix application startup failure by defining PasswordEncoder bean"

This commit resolves the issue causing the application to fail at startup by explicitly defining a PasswordEncoder bean in the security configuration. "Define PasswordEncoder bean for password encryption"

Added a PasswordEncoder bean in the SecurityConfig class to handle password encryption properly in the application. "Resolve missing PasswordEncoder bean error in UsersService"

Added the PasswordEncoder bean to the configuration to fix the injection error in the UsersServiceImp constructor.